### PR TITLE
unconditional menu transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,27 @@ To use the tiny menu, simply define the `tiny-menu-items` variable and then map
 keys to the items using the `tiny-menu-run-item` function.
 
 `tiny-menu-items` is an alist of menus ("items") where each menu key is the name
-of the menu and its value is the menu contents.  The menu contents is a list
-whose car is the name of the menu and cdr is a list of menu items.  Each menu
-item is a list with three elements: the raw character code a user must press to
-select the item, the display name for the item, and the function to be called
-when the item is selected.
+of the menu and its value is the menu contents. The menu contents is a list
+whose car is the name of the menu and cdr is a list of menu items. Each menu
+item is a list with three or four elements: the raw character code a user must
+press to select the item, the display name for the item, the function to be
+called when the item is selected, and (optionally) the menu to which to
+unconditionally transition afterward. A value of "root" signals a transition to
+the menu-of-menus, "quit" quits tiny-menu, and any invalid menu name results in
+in the menu-of-menus.
+
+If `tiny-menu-forever` is non-nil, then any omitted menu transition leaves
+tiny-menu on the current menu. If it is nil, then omitted transitions result in
+a quit.
 
 For example, it might look like this:
 
 ```
 '(("buffer-menu" ("Buffer operations"
-                  ((?k "Kill" kill-this-buffer)
-                   (?b "Bury" bury-buffer))))
+                  ((?k "Kill" kill-this-buffer "buffer-menu")
+                   (?b "Bury" bury-buffer "root"))))
   ("help-menu"   ("Help operations"
-                  ((?f "Describe function" describe-function)
+                  ((?f "Describe function" describe-function "quit")
                    (?k "Describe key"      describe-key)))))
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ item is a list with three or four elements: the raw character code a user must
 press to select the item, the display name for the item, the function to be
 called when the item is selected, and (optionally) the menu to which to
 unconditionally transition afterward. A value of "root" signals a transition to
-the menu-of-menus, "quit" quits tiny-menu, and any invalid menu name results in
-in the menu-of-menus.
+the menu-of-menus, "quit" quits tiny-menu.
 
 If `tiny-menu-forever` is non-nil, then any omitted menu transition leaves
 tiny-menu on the current menu. If it is nil, then omitted transitions result in
@@ -46,7 +45,8 @@ For example, it might look like this:
 ```
 '(("buffer-menu" ("Buffer operations"
                   ((?k "Kill" kill-this-buffer "buffer-menu")
-                   (?b "Bury" bury-buffer "root"))))
+                   (?b "Bury" bury-buffer "root")
+                   (?h "Goto help" nil "help-menu"))))
   ("help-menu"   ("Help operations"
                   ((?f "Describe function" describe-function "quit")
                    (?k "Describe key"      describe-key)))))

--- a/tiny-menu.el
+++ b/tiny-menu.el
@@ -1,4 +1,4 @@
-;;; tiny-menu.el --- Run a selected command from one menu.
+;;; tiny-menu.el --- Display tiny menus. -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2016 Aaron Bieber
 
@@ -55,8 +55,9 @@ then the default is to remain in the current menu. If
 `tiny-menu-forever' is nil, then omitting a new menu results in
 tiny-menu terminating after execution. The special value of
 \"quit\" indicates an unconditional quit from tiny-menu, and the
-value \"root\", and any invalid menu name, indicates an
-unconditional transition to the menu of menus.
+value \"root\" indicates an unconditional transition to the menu
+of menus. tiny-menu will report an error for an invalid
+transition name.
 
 The data structure should look like:
 
@@ -73,7 +74,7 @@ The data structure should look like:
      ((string-equal "root" next-menu) (tiny-menu--menu-of-menus))
      (t (if (assoc next-menu tiny-menu-items)
             (cadr (assoc next-menu tiny-menu-items))
-          (tiny-menu--menu-of-menus))))))
+          (error "The transition menu specified, \"%s\", is not a valid option. Check tiny-menu-items." next-menu))))))
 
 (defun tiny-menu (&optional menu)
   "Display the items in MENU and run the selected item.
@@ -83,7 +84,7 @@ is displayed."
   (interactive)
   (if (< (length tiny-menu-items) 1)
       (message "Configure tiny-menu-items first.")
-    (setq menu (tiny-menu--lookup-transition nil (if menu menu "root")))
+    (setq menu (tiny-menu--lookup-transition nil (or menu "root")))
     (while menu 
       (let* ((title (car menu))
              (items (append (cadr menu)
@@ -118,13 +119,13 @@ explicitly."
 
 (defun tiny-menu-run-item (item)
   "Return a function suitable for binding to call the ITEM run menu.
-
 This saves you the trouble of putting inline lambda functions in all
 of the key binding declarations for your menus.  A key binding
 declaration now looks like:
-
 `(define-key some-map \"<key>\" (tiny-menu-item \"my-menu\"))'."
-  `(lambda () (interactive) (tiny-menu ,item)))
+  (lambda ()
+    (interactive)
+    (tiny-menu item)))
 
 (provide 'tiny-menu)
 ;;; tiny-menu.el ends here

--- a/tiny-menu.el
+++ b/tiny-menu.el
@@ -1,4 +1,5 @@
-;;; tiny-menu.el --- Display tiny menus. -*- lexical-binding: t -*-
+;;; tiny-menu.el --- Run a selected command from one menu.
+;;; -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2016 Aaron Bieber
 
@@ -37,22 +38,38 @@
   "The menu heading shown in the selection menu for `tiny-menu'."
   :group 'tiny-menu)
 
+(defvar tiny-menu-forever nil
+  "If menu transitions are omitted, stay within the same menu until quit")
+
 (defvar tiny-menu-items
   '(())
   "An alist of menus.
 
 The keys in the alist are simple strings used to reference the menu in
-calls to `tiny-menu' and the values are lists with three elements:
-A raw character to use as the selection key, such as `?a'; a string to
-use in the menu display, and a function to call when that item is
-selected.
+calls to `tiny-menu' and the values are lists with four elements:
+a raw character to use as the selection key (such as `?a'), a string to
+use in the menu display, a function to call when that item is
+selected, and a new menu to display once the function has been run.
+
+If the new menu is omitted, and `tiny-menu-forever' is non-nil,
+then the default is to remain in the current menu. If
+`tiny-menu-forever' is nil, then omitting a new menu results in
+tiny-menu terminating after execution. The special value of
+\"quit\" indicates an unconditional quit from tiny-menu, and the
+value \"root\", and any invalid menu name, indicates an
+unconditional transition to the menu of menus.
 
 The data structure should look like:
 
-'((\"menu-1\" (?a \"First item\" function-to-call-for-item-1)
-            (?b \"Second item\" function-to-call-for-item-2))
-  (\"menu-2\" (?z \"First item\" function-to-call-for-item-1)
-            (?x \"Second item\" function-to-call-for-item-2)))")
+'((\"menu-name-1\" (\"menu-display-name\" (?a \"First item\" function-to-call-for-item-1 \"transition-menu\")
+      (?b \"Second item\" function-to-call-for-item-2 \"transition-menu\")))
+((\"menu-name-2 (\"\"menu-display-name\" (?z \"First item\" function-to-call-for-item-1 \"transition-menu\")
+                 (?x \"Second item\" function-to-call-for-item-2 \"transition-menu\")))))")
+
+(defun tiny-menu--lookup-menu-or-root (menu) 
+  (if (assoc menu tiny-menu-items)
+      (cadr (assoc menu tiny-menu-items))
+    (tiny-menu--menu-of-menus)))
 
 (defun tiny-menu (&optional menu)
   "Display the items in MENU and run the selected item.
@@ -61,27 +78,32 @@ If MENU is not given, a dynamically generated menu of available menus
 is displayed."
   (interactive)
   (if (< (length tiny-menu-items) 1)
-      (message "Configure tiny-menu-items first.")
-    (let* ((menu (if (assoc menu tiny-menu-items)
-                     (cadr (assoc menu tiny-menu-items))
-                   (tiny-menu--menu-of-menus)))
-           (title (car menu))
-           (items (append (cadr menu)
-                          '((?q "Quit" nil))))
-           (prompt (concat (propertize (concat title ": ") 'face 'default)
-                           (mapconcat (lambda (i)
-                                        (concat
-                                         (propertize (concat
-                                                      "[" (char-to-string (nth 0 i)) "] ")
-                                                     'face 'tiny-menu-heading-face)
-                                         (nth 1 i)))
-                                      items ", ")))
-                   (choices (mapcar (lambda (i) (nth 0 i)) items))
-                   (choice (read-char-choice prompt choices)))
-           (if (and (assoc choice items)
-                    (functionp (nth 2 (assoc choice items))))
-               (funcall (nth 2 (assoc choice items)))
-             (message "Menu aborted.")))))
+      (message "Configure tiny-menu-items first.") 
+    (setq menu (tiny-menu--lookup-menu-or-root menu))
+    (while menu 
+      (let* ((title (car menu))
+             (items (append (cadr menu)
+                            '((?q "Quit" nil "quit"))))
+             (prompt (concat (propertize (concat title ": ") 'face 'default)
+                             (mapconcat (lambda (i)
+                                          (concat
+                                           (propertize (concat
+                                                        "[" (char-to-string (nth 0 i)) "] ")
+                                                       'face 'tiny-menu-heading-face)
+                                           (nth 1 i)))
+                                        items ", ")))
+             (choices (mapcar (lambda (i) (nth 0 i)) items))
+             (choice (assoc (read-char-choice prompt choices) items))) 
+        (when (functionp (nth 2 choice))
+          (funcall (nth 2 choice)))
+        (let ((next-menu (nth 3 choice))) 
+          (if (null next-menu) 
+              (unless tiny-menu-forever (setq menu nil))
+            (setq menu (if (string-equal "quit" next-menu) nil
+                         (if (string-equal "root" next-menu)
+                             (tiny-menu--menu-of-menus)
+                           (tiny-menu--lookup-menu-or-root next-menu))))))))
+    (message "Menu aborted.")))
 
 (defun tiny-menu--menu-of-menus ()
   "Build menu items for all configured menus.
@@ -91,10 +113,10 @@ configured menus if the caller does not specify a menu name
 explicitly."
   (let ((menu-key-char 97))
     `("Menus" ,(mapcar (lambda (i)
-                (prog1
-                    `(,menu-key-char ,(car (car (cdr i))) (lambda () (tiny-menu ,(car i))))
-                  (setq menu-key-char (1+ menu-key-char))))
-              tiny-menu-items))))
+                         (prog1
+                             `(,menu-key-char ,(car (car (cdr i))) nil ,(car i))
+                           (setq menu-key-char (1+ menu-key-char))))
+                       tiny-menu-items))))
 
 (defun tiny-menu-run-item (item)
   "Return a function suitable for binding to call the ITEM run menu.
@@ -104,9 +126,7 @@ of the key binding declarations for your menus.  A key binding
 declaration now looks like:
 
 `(define-key some-map \"<key>\" (tiny-menu-item \"my-menu\"))'."
-  (lambda ()
-    (interactive)
-    (tiny-menu item)))
+  `(lambda () (interactive) (tiny-menu ,item)))
 
 (provide 'tiny-menu)
 ;;; tiny-menu.el ends here

--- a/tiny-menu.el
+++ b/tiny-menu.el
@@ -119,9 +119,11 @@ explicitly."
 
 (defun tiny-menu-run-item (item)
   "Return a function suitable for binding to call the ITEM run menu.
+
 This saves you the trouble of putting inline lambda functions in all
 of the key binding declarations for your menus.  A key binding
 declaration now looks like:
+
 `(define-key some-map \"<key>\" (tiny-menu-item \"my-menu\"))'."
   (lambda ()
     (interactive)


### PR DESCRIPTION
From the previous PR, 

I wanted to use tiny-menu for repeated movement and navigation stuff, but I couldn't if it quit after every call. Moreover, I felt that it would be nice if keys could send you to other menus, and to the root menu, and this allowed us to replace the recursive call to tiny-menu embedded in the menu-of-menus.

See the readme for an explanation, as well as the defvar docstrings. I also took the liberty of fixing the tiny-menu-run function, corrected the docstring for the defvar of tiny-menu-items.
